### PR TITLE
Add dockerfile file for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,11 @@ WORKDIR "${PICO_SDK_PATH}"
 RUN git submodule update --init
 
 WORKDIR "${PRK_HOME}"
-ARG REPO_URL
-ARG REPO_NAME
+ARG KEYBOARD
 
 WORKDIR "${PRK_HOME}/keyboards"
 
-RUN git clone $REPO_URL
-WORKDIR "${PRK_HOME}/keyboards/${REPO_NAME}/build"
+WORKDIR "${PRK_HOME}/keyboards/${KEYBOARD}/build"
 
 RUN cmake ../../..
 RUN make
@@ -39,9 +37,11 @@ RUN make
 FROM scratch AS export
 
 ENV PRK_HOME /prk_firmware
-COPY --from=build "${PRK_HOME}/keyboards/${REPO_NAME}" "./${REPO_NAME}"
+COPY --from=build "${PRK_HOME}/keyboards/${KEYBOARD}" "./${KEYBOARD}"
 
-# ex. docker build -o keyboards --build-arg REPO_NAME=prk_meishi2 --build-arg REPO_URL=https://github.com/picoruby/prk_meishi2.git .
-# ex. docker build -o keyboards --build-arg REPO_NAME=prk_crkbd --build-arg REPO_URL=https://github.com/picoruby/prk_crkbd.git .
-# ex. docker build -o keyboards --build-arg REPO_NAME=prk_claw44 --build-arg REPO_URL=https://github.com/picoruby/prk_claw44.git .
-
+# ex. git clone https://github.com/picoruby/prk_meishi2.git keyboards/prk_meishi2 &&
+#     docker build -o keyboards --build-arg KEYBOARD=prk_meishi2 --build-arg .
+# ex. git clone https://github.com/picoruby/prk_meishi2.git keyboards/prk_crkbd &&
+#     docker build -o keyboards --build-arg KEYBOARD=prk_crkbd --build-arg .
+# ex. git clone https://github.com/picoruby/prk_meishi2.git keyboards/prk_claw44 &&
+#     docker build -o keyboards --build-arg KEYBOARD=prk_claw44 --build-arg .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM debian:10-slim AS build
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  cmake \
+  gcc-arm-none-eabi \
+  libnewlib-arm-none-eabi \
+  libstdc++-arm-none-eabi-newlib \
+  ca-certificates \
+  git \
+  gcc \
+  make \
+  g++ \
+  python3 \
+  ruby
+
+ENV PRK_HOME /prk_firmware
+
+VOLUME "${PRK_HOME}"
+WORKDIR "${PRK_HOME}"
+COPY . .
+
+RUN git clone https://github.com/raspberrypi/pico-sdk.git
+ENV PICO_SDK_PATH "${PRK_HOME}/pico-sdk"
+WORKDIR "${PICO_SDK_PATH}"
+RUN git submodule update --init
+
+WORKDIR "${PRK_HOME}"
+ARG REPO_URL
+ARG REPO_NAME
+
+WORKDIR "${PRK_HOME}/keyboards"
+
+RUN git clone $REPO_URL
+WORKDIR "${PRK_HOME}/keyboards/${REPO_NAME}/build"
+
+RUN cmake ../../..
+RUN make
+
+FROM scratch AS export
+
+ENV PRK_HOME /prk_firmware
+COPY --from=build "${PRK_HOME}/keyboards/${REPO_NAME}" "./${REPO_NAME}"
+
+# ex. docker build -o keyboards --build-arg REPO_NAME=prk_meishi2 --build-arg REPO_URL=https://github.com/picoruby/prk_meishi2.git .
+# ex. docker build -o keyboards --build-arg REPO_NAME=prk_crkbd --build-arg REPO_URL=https://github.com/picoruby/prk_crkbd.git .
+# ex. docker build -o keyboards --build-arg REPO_NAME=prk_claw44 --build-arg REPO_URL=https://github.com/picoruby/prk_claw44.git .
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ ENV PRK_HOME /prk_firmware
 COPY --from=build "${PRK_HOME}/keyboards/${KEYBOARD}" "./${KEYBOARD}"
 
 # ex. git clone https://github.com/picoruby/prk_meishi2.git keyboards/prk_meishi2 &&
-#     docker build -o keyboards --build-arg KEYBOARD=prk_meishi2 --build-arg .
-# ex. git clone https://github.com/picoruby/prk_meishi2.git keyboards/prk_crkbd &&
-#     docker build -o keyboards --build-arg KEYBOARD=prk_crkbd --build-arg .
-# ex. git clone https://github.com/picoruby/prk_meishi2.git keyboards/prk_claw44 &&
-#     docker build -o keyboards --build-arg KEYBOARD=prk_claw44 --build-arg .
+#     docker build -o keyboards --build-arg KEYBOARD=prk_meishi2 .
+# ex. git clone https://github.com/picoruby/prk_crkbd.git keyboards/prk_crkbd &&
+#     docker build -o keyboards --build-arg KEYBOARD=prk_crkbd .
+# ex. git clone https://github.com/picoruby/prk_claw44.git keyboards/prk_claw44 &&
+#     docker build -o keyboards --build-arg KEYBOARD=prk_claw44 .


### PR DESCRIPTION
Hi. I would like to try to build prk_firmware on my mac, but I could not get it to work.
I thought that adding the option to build with docker would make it easier for mac users to build.

I wrote a dockerfile file for build.
The following docker command will output the uf2 file in the directory (prk_firmware/keyboards/prk_meishi2/build).

```
docker build -o keyboards \
--build-arg REPO_NAME=prk_meishi2 \
--build-arg REPO_URL=https://github.com/picoruby/prk_meishi2.git .
```

Please consider it. 
Thanks.