### PR TITLE
Add zip and build picoruby before prk_firmware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   gcc \
   make \
   g++ \
+  zip \
   python3 \
   ruby
 
@@ -27,6 +28,9 @@ RUN git clone https://github.com/raspberrypi/pico-sdk.git
 ENV PICO_SDK_PATH "${PRK_HOME}/pico-sdk"
 WORKDIR "${PICO_SDK_PATH}"
 RUN git submodule update --init
+
+WORKDIR "${PRK_HOME}/lib/picoruby"
+RUN make
 
 WORKDIR "${PRK_HOME}"
 ARG KEYBOARD


### PR DESCRIPTION
zip is required for packaging, and docker build failed wihtout picoruby build:

```
$ docker build -o keyboards --build-arg KEYBOARD=prk_runner3680_5x7 .
[+] Building 22.1s (18/20)
 => [internal] load build definition from Dockerfile                       0.0s
 => => transferring dockerfile: 1.34kB                                     0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [internal] load metadata for docker.io/library/ruby:3.0.1-slim         0.9s
 => [build  1/15] FROM docker.io/library/ruby:3.0.1-slim@sha256:b142cf5af  0.0s
 => [internal] load build context                                          0.5s
 => => transferring context: 14.31MB                                       0.5s
 => CACHED [build  2/15] RUN apt-get update && apt-get install --no-insta  0.0s
 => CACHED [build  3/15] WORKDIR /prk_firmware                             0.0s
 => [build  4/15] COPY . .                                                 0.5s
 => [build  5/15] WORKDIR /prk_firmware/src/ruby                           0.0s
 => [build  6/15] RUN bundle install                                      12.6s
 => [build  7/15] WORKDIR /prk_firmware                                    0.0s
 => [build  8/15] RUN git clone https://github.com/raspberrypi/pico-sdk.g  1.5s
 => [build  9/15] WORKDIR /prk_firmware/pico-sdk                           0.0s
 => [build 10/15] RUN git submodule update --init                          5.0s
 => [build 11/15] WORKDIR /prk_firmware                                    0.0s
 => [build 12/15] WORKDIR /prk_firmware/keyboards                          0.0s
 => [build 13/15] WORKDIR /prk_firmware/keyboards/prk_runner3680_5x7/buil  0.0s
 => ERROR [build 14/15] RUN cmake ../../..                                 0.7s
------
 > [build 14/15] RUN cmake ../../..:
#18 0.267 PICO_SDK_PATH is /prk_firmware/pico-sdk
#18 0.267 PICO platform is rp2040.
#18 0.285 PICO target board is pico.
#18 0.286 Using board configuration from /prk_firmware/pico-sdk/src/boards/include/boards/pico.h
#18 0.436 TinyUSB available at /prk_firmware/pico-sdk/lib/tinyusb/src/portable/raspberrypi/rp2040; adding USB support.
#18 0.441 Including custom CMake file /prk_firmware/pico-sdk/src/common/pico_base/generate_config_header.cmake
#18 0.473 PIOASM will need to be built
#18 0.521 ELF2UF2 will need to be built
#18 0.541 -- Configuring done
#18 0.555 CMake Error at lib/CMakeLists.txt:15 (add_library):
#18 0.555   Cannot find source file:
#18 0.555
#18 0.555     ./picoruby/src/mrubyc/src/mrblib.c
#18 0.555
#18 0.555   Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
#18 0.555   .hpp .hxx .in .txx
#18 0.555
#18 0.555
#18 0.676 -- Generating done
#18 0.687 -- Build files have been written to: /prk_firmware/keyboards/prk_runner3680_5x7/build
------
executor failed running [/bin/sh -c cmake ../../..]: exit code: 1
```
