### PR TITLE
Proposal : Support split_style property

### DIFF
--- a/src/ruby/lib/keyboard.rb
+++ b/src/ruby/lib/keyboard.rb
@@ -521,17 +521,7 @@ class Keyboard
     cols_size = @split ? @cols.size * 2 : @cols.size
     map.each do |key|
       new_map[row_index] = Array.new(@cols.size) if col_index == 0
-      key = KC_ALIASES[key] ? KC_ALIASES[key] : key
-      keycode_index = KEYCODE.index(key)
-      new_map[row_index][col_index] = if keycode_index
-        keycode_index * -1
-      elsif KEYCODE_SFT[key]
-        (KEYCODE_SFT[key] + 0x100) * -1
-      elsif MOD_KEYCODE[key]
-        MOD_KEYCODE[key]
-      else
-        key
-      end
+      new_map[row_index][col_index] = find_keycode_index(key)
       if col_index == cols_size - 1
         col_index = 0
         row_index += 1
@@ -541,6 +531,21 @@ class Keyboard
     end
     @keymaps[name] = new_map
     @layer_names << name
+  end
+
+  def find_keycode_index(key)
+    key = KC_ALIASES[key] ? KC_ALIASES[key] : key
+    keycode_index = KEYCODE.index(key)
+
+    if keycode_index
+      keycode_index * -1
+    elsif KEYCODE_SFT[key]
+      (KEYCODE_SFT[key] + 0x100) * -1
+    elsif MOD_KEYCODE[key]
+      MOD_KEYCODE[key]
+    else
+      key
+    end
   end
 
   # param[0] :on_release

--- a/src/ruby/lib/keyboard.rb
+++ b/src/ruby/lib/keyboard.rb
@@ -404,6 +404,9 @@ class Keyboard
   }
   letter = nil
 
+  STANDARD_SPLIT = :standard_split
+  RIGHT_SIDE_FLIPPED_SPLIT = :right_side_flipped_split
+
   def initialize
     puts "Initializing Keyboard ..."
     # mruby/c VM doesn't work with a CONSTANT to make another CONSTANT
@@ -419,6 +422,7 @@ class Keyboard
     @layer_names = Array.new
     @layer = :default
     @split = false
+    @split_style = STANDARD_SPLIT
     @anchor = true
     @anchor_left = true # so-called "master left"
     @uart_pin = 1
@@ -430,7 +434,7 @@ class Keyboard
   end
 
   attr_accessor :split, :uart_pin
-  attr_reader :layer
+  attr_reader :layer, :split_style
 
   # TODO: OLED, SDCard
   def append(feature)
@@ -466,6 +470,16 @@ class Keyboard
   # val should be treated as `:left` if it's anything other than `:right`
   def set_anchor(val)
     @anchor_left = false if val == :right
+  end
+
+  def split_style=(style)
+    case style
+    when STANDARD_SPLIT, RIGHT_SIDE_FLIPPED_SPLIT
+      @split_style = style
+    else
+      # NOTE: fall back
+      @split_style = STANDARD_SPLIT
+    end
   end
 
   def init_pins(rows, cols)

--- a/src/ruby/lib/keyboard.rb
+++ b/src/ruby/lib/keyboard.rb
@@ -518,11 +518,12 @@ class Keyboard
     new_map = Array.new(@rows.size)
     row_index = 0
     col_index = 0
-    cols_size = @split ? @cols.size * 2 : @cols.size
+    @cols_size = @split ? @cols.size * 2 : @cols.size
     map.each do |key|
       new_map[row_index] = Array.new(@cols.size) if col_index == 0
-      new_map[row_index][col_index] = find_keycode_index(key)
-      if col_index == cols_size - 1
+      col_position = calculate_col_position(col_index)
+      new_map[row_index][col_position] = find_keycode_index(key)
+      if col_index == @cols_size - 1
         col_index = 0
         row_index += 1
       else
@@ -531,6 +532,21 @@ class Keyboard
     end
     @keymaps[name] = new_map
     @layer_names << name
+  end
+
+  def calculate_col_position(col_index)
+    return col_index unless @split
+
+    case @split_style
+    when STANDARD_SPLIT
+      col_index
+    when RIGHT_SIDE_FLIPPED_SPLIT
+      if col_index < @cols.size
+        col_index
+      else
+        @cols_size - (col_index - @cols.size) - 1
+      end
+    end
   end
 
   def find_keycode_index(key)

--- a/src/ruby/lib/keyboard.rb
+++ b/src/ruby/lib/keyboard.rb
@@ -518,12 +518,12 @@ class Keyboard
     new_map = Array.new(@rows.size)
     row_index = 0
     col_index = 0
-    @cols_size = @split ? @cols.size * 2 : @cols.size
+    @entire_cols_size = @split ? @cols.size * 2 : @cols.size
     map.each do |key|
       new_map[row_index] = Array.new(@cols.size) if col_index == 0
       col_position = calculate_col_position(col_index)
       new_map[row_index][col_position] = find_keycode_index(key)
-      if col_index == @cols_size - 1
+      if col_index == @entire_cols_size - 1
         col_index = 0
         row_index += 1
       else
@@ -544,7 +544,7 @@ class Keyboard
       if col_index < @cols.size
         col_index
       else
-        @cols_size - (col_index - @cols.size) - 1
+        @entire_cols_size - (col_index - @cols.size) - 1
       end
     end
   end

--- a/src/ruby/sig/keyboard.rbs
+++ b/src/ruby/sig/keyboard.rbs
@@ -14,6 +14,8 @@ class Keyboard
   KEYCODE_SFT: Hash[Symbol, Integer]
   LETTER: Array[String | Symbol | nil]
   KC_ALIASES: Hash[Symbol, Symbol]
+  STANDARD_SPLIT: Symbol
+  RIGHT_SIDE_FLIPPED_SPLIT: Symbol
 
   @SHIFT_LETTER_OFFSET_A: Integer
   @SHIFT_LETTER_OFFSET_UNDS: Integer
@@ -48,6 +50,7 @@ class Keyboard
   @macro_keys: Array[Integer]
   @macro_key_numbers: Array[Integer | nil]
   @modifier: Integer
+  @split_style: Symbol
 
   attr_accessor split: bool
   attr_accessor uart_pin: Integer
@@ -62,8 +65,11 @@ class Keyboard
   def initialize: -> void
   def layer: () -> Symbol
   def set_anchor: (Symbol val) -> void
+  def split_style=: (Symbol style) -> void
   def init_pins: (Array[Integer] rows, Array[Integer] cols) -> void
   def add_layer: (Symbol name, Array[Symbol] map) -> void
+  def calculate_col_position: (Integer col_index) -> Integer
+  def find_keycode_index: (Symbol key) -> (Integer | Symbol)
   def define_mode_key: (Symbol key_name, [Symbol | Array[Symbol] | Proc | nil, Symbol | Proc, Integer?, Integer?] param) -> void
   def invert_sft: -> void
   def before_report: () { () -> void } -> void


### PR DESCRIPTION
Some split keyboards (ex: Zinc) are defined in the opposite order from that specified by `Keyboard#add_layer`.
When I created the `keymap.rb` for Zinc, I need [some hacks](https://gist.github.com/takkanm/bf937b83c67c42d801a31af20132d244#file-keymap-rb-L41-L46).

So I would like to propose a new property`Keyboard#split_style` to support those keyboard definitions.
This property has two options.

- STANDARD_SPLIT (default) : ex: crkbd, claw44, silver_bullet
- RIGHT_SIDE_FLIPPED_SPLIT : ex: Zinc, Let's split (some version)
  - This name is a reference to https://github.com/qmk/qmk_firmware/blob/ef5c6ea096033423c9b9e141c1fc94dcc41d84fa/keyboards/lets_split/rev2/rev2.h#L35 .

With this change, Zinc can now be defined as follows.

```ruby
kbd = Keyboard.new

kbd.split = true

kbd.split_style = :right_side_flipped_split

kbd.init_pins(
  [ 27, 26, 22, 20 ],
  [ 29, 4, 5, 6, 7, 8 ]
)

kbd.add_layer :default, %i[
  KC_TAB  KC_Q   KC_W    KC_E      KC_R  KC_T  KC_Y     KC_U       KC_I    KC_O      KC_P KC_BSPACE 
  CTL_ESC KC_A   KC_S    KC_D      KC_F  KC_G KC_H     KC_J       KC_K    KC_L KC_SCOLON  KC_QUOTE 
  KC_LSFT KC_Z   KC_X    KC_C      KC_V  KC_B )KC_N     KC_M   KC_COMMA  KC_DOT  KC_SLASH   KC_RSFT 
  KC_ESC  ADJUST KC_LALT CMD_LANG2 RAISE KC_SPACE KC_ENTER LOWER ALT_LANG1 KC_DOWN     KC_UP   KC_RGHT 
]
```

