### PR TITLE
Direct scan support

### DIFF
--- a/src/ruby/app/models/keyboard.rb
+++ b/src/ruby/app/models/keyboard.rb
@@ -458,6 +458,7 @@ class Keyboard
     @partner_encoders = Array.new
     @macro_keycodes = Array.new
     @buffer = Buffer.new("picoirb")
+    @scan_mode = :matrix
   end
 
   attr_accessor :split, :uart_pin
@@ -510,6 +511,15 @@ class Keyboard
     end
   end
 
+  def set_scan_mode(mode)
+    case mode
+    when :matrix, :direct
+      @scan_mode = mode
+    else
+      puts 'Scan mode only support :matrix and :direct. (default: :matrix)'
+    end
+  end
+
   def init_pins(rows, cols)
     puts "Initializing GPIO ..."
     if @split
@@ -539,6 +549,11 @@ class Keyboard
     # for split type
     @offset_a = (@cols.size / 2.0).ceil_to_i
     @offset_b = @cols.size * 2 - @offset_a - 1
+  end
+
+  def init_direct_pins(pins)
+    set_scan_mode :direct
+    init_pins([], pins)
   end
 
   # Input
@@ -790,7 +805,7 @@ class Keyboard
       @switches.clear
       @modifier = 0
 
-      @switches = scan_matrix!
+      @switches = @scan_mode == :matrix ? scan_matrix! : scan_direct!
 
       # TODO: more features
       $rgb.fifo_push(true) if $rgb && !@switches.empty?

--- a/src/ruby/app/models/keyboard.rb
+++ b/src/ruby/app/models/keyboard.rb
@@ -997,6 +997,16 @@ class Keyboard
     return switches
   end
 
+  def scan_direct!
+    switches = []
+    @cols.each_with_index do |col_pin, col|
+      if gpio_get(col_pin) == LO
+        switches << [0, col]
+      end
+    end
+    return switches
+  end
+
   #
   # Actions can be used in keymap.rb
   #

--- a/src/ruby/sig/keyboard.rbs
+++ b/src/ruby/sig/keyboard.rbs
@@ -95,4 +95,5 @@ class Keyboard
   def eval: (String) -> void
   def ruby: () -> void
   def scan_matrix!: () -> Array[Array[Integer]]
+  def scan_direct!: () -> Array[Array[Integer]]
 end

--- a/src/ruby/sig/keyboard.rbs
+++ b/src/ruby/sig/keyboard.rbs
@@ -58,6 +58,7 @@ class Keyboard
   @split_style: Symbol
   @message: Integer
   @encoders: Array[RotaryEncoder]
+  @scan_mode: Symbol
 
   attr_accessor split: bool
   attr_accessor uart_pin: Integer
@@ -74,8 +75,10 @@ class Keyboard
   def initialize: -> void
   def layer: () -> Symbol
   def set_anchor: (Symbol val) -> void
+  def set_scan_mode: (Symbol val) -> void
   def split_style=: (Symbol style) -> void
   def init_pins: (Array[Integer] rows, Array[Integer] cols) -> void
+  def init_direct_pins: (Array[Integer] pins) -> void
   def add_layer: (Symbol name, Array[Symbol] map) -> void
   def calculate_col_position: (Integer col_index) -> Integer
   def find_keycode_index: (Symbol key) -> (Integer | Symbol)

--- a/src/ruby/sig/keyboard.rbs
+++ b/src/ruby/sig/keyboard.rbs
@@ -94,4 +94,5 @@ class Keyboard
   def macro: (String text, ?::Array[Symbol] opt) -> void
   def eval: (String) -> void
   def ruby: () -> void
+  def scan_matrix!: () -> Array[Array[Integer]]
 end


### PR DESCRIPTION
Some keyboards support direct scan. e.g. https://www.sho-k.co.uk/tech/1246.html
These keyboards do not use a matrix, but use one pin per key.

This PR is working on those keyboards as well.

When defining these keyboards, the following writing style was supported.

```ruby
kbd.set_scan_mode = :direct
kbd.init_pins(
  [],
  [ 8, 27, 28, 29, 9, 26 ]
)
```
or

```ruby
kbd.init_direct_pins(
  [ 8, 27, 28, 29, 9, 26 ]
)
```
