### PR TITLE
Users can change VID/PID/ProductName by `via-conf.txt`

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,85 @@
 #include "ruby/app/keymap.c"
 #endif
 
+//--------------------------------------------------------------------+
+// Device Descriptors
+//--------------------------------------------------------------------+
+tusb_desc_device_t desc_device =
+{
+  .bLength            = sizeof(tusb_desc_device_t),
+  .bDescriptorType    = TUSB_DESC_DEVICE,
+  .bcdUSB             = 0x0200,
+  // Use Interface Association Descriptor (IAD) for CDC
+  // As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
+  .bDeviceClass       = TUSB_CLASS_MISC,
+  .bDeviceSubClass    = MISC_SUBCLASS_COMMON,
+  .bDeviceProtocol    = MISC_PROTOCOL_IAD,
+  .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
+  /*
+   * VID and PID from USB-IDs-for-free.txt
+   * https://github.com/obdev/v-usb/blob/releases/20121206/usbdrv/USB-IDs-for-free.txt#L128
+   */
+  .idVendor           = 0x16c0,
+  .idProduct          = 0x27db,
+  .bcdDevice          = 0x0100,
+  .iManufacturer      = 0x01,
+  .iProduct           = 0x02,
+  .iSerialNumber      = 0x03,
+  .bNumConfigurations = 0x01
+};
+
+//--------------------------------------------------------------------+
+// String Descriptors
+//--------------------------------------------------------------------+
+#include "version.h"
+#define PRK_SERIAL (PRK_VERSION "-" PRK_BUILDDATE "-" PRK_REVISION)
+char const *string_desc_arr[] =
+{
+  (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
+  "PicoRuby developers",         // 1: Manufacturer
+  "PRK Firmwre",                 // 2: Product
+  PRK_SERIAL,                    // 3: Serial
+  "PRK CDC",                     // 4: CDC Interface
+  "PRK MSC",                     // 5: MSC Interface
+};
+/*
+ * If you want users to use the VIA feature, provide them `via-conf.txt`
+ * file in order to VIA/Remap can determine the layout of the keyboard.
+ * Format of the content `via-conf.txt`:
+ *   0x1234:0xABCD:productName
+ *   ^^^^^^ ^^^^^^ ^^^^^^^^^^^
+ *    VID    PID      Name
+ *   - IDs' prefix should be `0x`, should NOT be `0X`
+ *   - Length of productName should be less than or equal 32 bytes
+ * and any other letter must not be included in the file.
+ */
+#define VIA_CONF_LENGTH (7 + 7 + 32)
+static void
+configure_vid_pid(void)
+{
+  DirEnt entry;
+  uint8_t buf[VIA_CONF_LENGTH + 1] = {0};
+  uint8_t vid[7] = {0};
+  uint8_t pid[7] = {0};
+  static char name[VIA_CONF_LENGTH - 14] = {0};
+  msc_findDirEnt("VIA-CONFTXT", &entry);
+  if (entry.Name[0] != '\0') {
+    if (entry.FileSize > VIA_CONF_LENGTH) return;
+    msc_loadFile(buf, &entry);
+    if (strncmp("0x", buf, 2) || strncmp(":0x", buf + 6, 3)) return;
+    memcpy(vid,  buf     , 6);
+    memcpy(pid,  buf +  7, 6);
+    memcpy(name, buf + 14, strlen(buf) - 14);
+    for (int i = 0; ; i++) {
+      if (name[i] == '\r' || name[i] == '\n') name[i] = '\0';
+      if (name[i] == '\0') break;
+    }
+    desc_device.idVendor  = (uint16_t)strtol(vid, NULL, 16);
+    desc_device.idProduct = (uint16_t)strtol(pid, NULL, 16);
+    string_desc_arr[2] = (const char *)name;
+  }
+}
+
 void
 c___reset_usb_boot(mrb_vm *vm, mrb_value *v, int argc)
 {
@@ -183,6 +262,8 @@ int loglevel;
 
 int main() {
   loglevel = LOGLEVEL_WARN;
+
+  configure_vid_pid();
 
   stdio_init_all();
   board_init();

--- a/src/main.c
+++ b/src/main.c
@@ -65,11 +65,11 @@ tusb_desc_device_t desc_device =
 //--------------------------------------------------------------------+
 #include "version.h"
 #define PRK_SERIAL (PRK_VERSION "-" PRK_BUILDDATE "-" PRK_REVISION)
-char const *string_desc_arr[] =
+char const *string_desc_arr[STRING_DESC_ARR_SIZE] =
 {
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
-  "PicoRuby developers",         // 1: Manufacturer
-  "PRK Firmwre",                 // 2: Product
+  "PRK Firmware developers",     // 1: Manufacturer
+  "Default VID/PID"              // 2: Product
   PRK_SERIAL,                    // 3: Serial
   "PRK CDC",                     // 4: CDC Interface
   "PRK MSC",                     // 5: MSC Interface

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -27,49 +27,12 @@
 
 #include "usb_descriptors.h"
 
-/* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
- * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
- *
- * Auto ProductID layout's Bitmap:
- *   [MSB]         HID | MSC | CDC          [LSB]
- */
-#define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
-#define USB_PID           (0x8000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
-                           _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
-
-//--------------------------------------------------------------------+
-// Device Descriptors
-//--------------------------------------------------------------------+
-tusb_desc_device_t const desc_device =
-{
-    .bLength            = sizeof(tusb_desc_device_t),
-    .bDescriptorType    = TUSB_DESC_DEVICE,
-    .bcdUSB             = 0x0200,
-
-    // Use Interface Association Descriptor (IAD) for CDC
-    // As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
-    .bDeviceClass       = TUSB_CLASS_MISC,
-    .bDeviceSubClass    = MISC_SUBCLASS_COMMON,
-    .bDeviceProtocol    = MISC_PROTOCOL_IAD,
-
-    .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
-
-    .idVendor           = 0xCafe,
-    .idProduct          = USB_PID,
-    .bcdDevice          = 0x0100,
-
-    .iManufacturer      = 0x01,
-    .iProduct           = 0x02,
-    .iSerialNumber      = 0x03,
-
-    .bNumConfigurations = 0x01
-};
-
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
 uint8_t const * tud_descriptor_device_cb(void)
 {
-  return (uint8_t const *) &desc_device;
+  /* desc_device is defined in main.c */
+  return (uint8_t const *)&desc_device;
 }
 
 //--------------------------------------------------------------------+
@@ -171,21 +134,6 @@ uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
   return desc_fs_configuration;
 }
 
-//--------------------------------------------------------------------+
-// String Descriptors
-//--------------------------------------------------------------------+
-
-// array of pointer to string descriptors
-char const* string_desc_arr [] =
-{
-  (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
-  "Raspberry Pi",                // 1: Manufacturer
-  "RP2040",                      // 2: Product
-  "123456",                      // 3: Serials, should use chip ID
-  "TinyUSB CDC",                 // 4: CDC Interface
-  "TinyUSB MSC",                 // 5: MSC Interface
-};
-
 static uint16_t _desc_str[32];
 
 // Invoked when received GET STRING DESCRIPTOR request
@@ -205,7 +153,7 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
     // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
     // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
 
-    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
+//    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
 
     const char* str = string_desc_arr[index];
 

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -153,7 +153,7 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
     // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
     // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
 
-//    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
+    if ( !(index < STRING_DESC_ARR_SIZE) ) return NULL;
 
     const char* str = string_desc_arr[index];
 

--- a/src/usb_descriptors.h
+++ b/src/usb_descriptors.h
@@ -13,6 +13,8 @@ extern char *iProduct;
 
 extern char const *string_desc_arr[];
 
+#define STRING_DESC_ARR_SIZE 6
+
 enum {
   REPORT_ID_KEYBOARD = 1,
   REPORT_ID_MOUSE,

--- a/src/usb_descriptors.h
+++ b/src/usb_descriptors.h
@@ -1,8 +1,17 @@
+#ifndef USB_DESCRIPTORS_H_
+#define USB_DESCRIPTORS_H_
+
 /* mruby/c VM */
 #include <mrubyc.h>
 
-#ifndef USB_DESCRIPTORS_H_
-#define USB_DESCRIPTORS_H_
+/* TinyUSB */
+#include "tusb.h"
+
+extern tusb_desc_device_t desc_device;
+
+extern char *iProduct;
+
+extern char const *string_desc_arr[];
 
 enum {
   REPORT_ID_KEYBOARD = 1,


### PR DESCRIPTION
## Background

- In order to take advantage of the VIA feature (#57), VID and PID should be configurable
- According to @yoichiro, Remap uses the "product name" in addition to the above

## Solution

- Dragging and dropping `via-conf.txt` file (then reboot the board) changes the values  
  ![image](https://user-images.githubusercontent.com/8454208/164190051-eb6f4c78-875f-403e-8e31-e080ccb58ae7.png)

- The format of the content: `[VID]:[PID]:[Product name]`

## Example
If `via-conf.txt` includes this content,

```
0xbc42:0x0003:MyKeyboardName
```

these values are going to be applied as the image shows:

![image](https://user-images.githubusercontent.com/8454208/164189217-608553ae-ac19-4beb-bfbd-87d7f7adbc1e.png)
