### PR TITLE
change loading VIA keymap method

### DIFF
--- a/src/msc_disk.c
+++ b/src/msc_disk.c
@@ -384,16 +384,10 @@ c_read_file(mrb_vm *vm, mrb_value *v, int argc) {
   uint16_t sector = GET_INT_ARG(1);
   uint16_t length = GET_INT_ARG(2);
 
-  mrbc_value rb_val_array = mrbc_array_new(vm, length);
-  mrbc_array *rb_array = rb_val_array.array;
   uint8_t *data = msc_read_sector(sector);
-
-  rb_array->n_stored = length;
-  for(uint16_t i=0; i<length; i++) {
-    mrbc_set_integer( (rb_array->data)+i, data[i] );
-  }
-
-  SET_RETURN(rb_val_array);
+  mrbc_value rb_val_str = mrbc_string_new(vm, data, length);
+  
+  SET_RETURN(rb_val_str);
 }
 
 void

--- a/src/ruby/app/models/via.rb
+++ b/src/ruby/app/models/via.rb
@@ -30,7 +30,7 @@ class VIA
     ID_SWITCH_MATRIX_STATE
   ]
 
-  VIA_FILENAME = "VIA_MAP RB "
+  VIA_FILENAME = "VIA_MAP TXT"
 
   def initialize
     puts "Initializing VIA."
@@ -276,7 +276,7 @@ class VIA
   end
 
   def save_on_flash
-    data = "keymap = [ \n%i[ "
+    data = ""
 
     @layer_count.times do |i|
       @rows_size.times do |j|
@@ -285,13 +285,13 @@ class VIA
           data << key.to_s + " "
         end
 
-        data << " \n    "
+        data << " \n"
       end
 
-      data << "], \n\n%i[ "
+      data << ",\n"
     end
 
-    data << "KC_NO ] \n]\n"
+    data << ""
     
     write_file_internal(VIA_FILENAME, data)
   end
@@ -302,14 +302,20 @@ class VIA
     fileinfo = find_file(VIA_FILENAME)
     
     if fileinfo
-      puts "via_map.rb found"
-      script = ""
-      ary = read_file(fileinfo[0], fileinfo[1])
-      ary.each do |i|
-        script << i.chr;
+      puts "via_map.txt found"
+      script = read_file(fileinfo[0], fileinfo[1])
+      
+      ret = []
+      layers = script.split(",")
+      layers.size.times do |l|
+          ret[l] = []
+          rows = layers[l].split("\n")
+          rows.each do |row|
+              row.split(" ").each do |kc|
+                  ret[l] << kc.intern
+              end
+          end
       end
-
-      ret = eval_val(script)
     
       if ret.class == Array
         puts "loading VIA map"

--- a/src/ruby/sig/object.rbs
+++ b/src/ruby/sig/object.rbs
@@ -28,5 +28,5 @@ class Object
   def gpio_get : (Integer) -> bool
   def write_file_internal : (String, String) -> void
   def find_file : (String) -> ( [Integer, Integer] | nil )
-  def read_file : (Integer, Integer) -> Array[Integer]
+  def read_file : (Integer, Integer) -> String
 end


### PR DESCRIPTION
Increase VIA keymap size to 200 keys ( I tested works with 4\*6\*9=216keys, not works with 4\*6\*10=240keys because of `Out of Memory` ) from 36keys.

* Record file changed to `via_map.txt`. Not `via_map.rb`
* Record is read by string manipulation. Not by executing in interpreter.
* Ruby `read_file` returns `String`. It previously returns `Array of Integer`.

[via_map.txt](https://github.com/picoruby/prk_firmware/files/8564511/via_map.txt)
