### PR TITLE
use KEYCODE_SFT keycodes on VIA

### DIFF
--- a/src/ruby/app/models/keyboard.rb
+++ b/src/ruby/app/models/keyboard.rb
@@ -714,10 +714,6 @@ class Keyboard
     end
   end
 
-  def keycode_to_keysym(keycode)
-    return KEYCODE[keycode] || :KC_NO
-  end
-
   def entire_cols_size
     @entire_cols_size ||= @split ? @cols_size * 2 : @cols_size
   end

--- a/src/ruby/sig/keyboard.rbs
+++ b/src/ruby/sig/keyboard.rbs
@@ -128,5 +128,4 @@ class Keyboard
   def resolve_key_alias: (Symbol) -> Symbol
   def get_layer: (Symbol | nil, Integer) -> ( Array[Array[Integer | Symbol | Proc]] | nil )
   def delete_mode_keys: (Symbol) -> void
-  def keycode_to_keysym: (Integer) -> Symbol
 end

--- a/src/ruby/sig/via.rbs
+++ b/src/ruby/sig/via.rbs
@@ -25,7 +25,7 @@ class VIA
   def dynamic_keymap_get_keycode : (Integer, Integer, Integer) -> Integer
   def dynamic_keymap_set_keycode : (Integer, Integer, Integer, Integer) -> void
   def via_get_layer_name : (Integer) -> Symbol
-  def via_keycode_into_prk_keycode : (Integer) -> ( [Integer, Integer] | Symbol | Integer )
+  def check_for_keycode_shift : (Integer) -> ( Symbol | nil )
   def via_keycode_into_keysymbol : (Integer) -> Symbol
   def prk_keycode_into_via_keycode : (Integer | Symbol | Proc) -> Integer
   def expand_composite_key : (Symbol) -> Array[Symbol]

--- a/src/ruby/test/keyboard_test.rb
+++ b/src/ruby/test/keyboard_test.rb
@@ -213,9 +213,4 @@ class KeyboardTest < MrubycTestCase
     @kbd.ruby
     assert_equal true, @kbd.instance_variable_get("@ruby_mode")
   end
-
-  description "keycode translation"
-  def keycode_to_keysym
-    assert_equal(:KC_A, @kbd.keycode_to_keysym(4) )
-  end
 end

--- a/src/ruby/test/via_test.rb
+++ b/src/ruby/test/via_test.rb
@@ -11,13 +11,13 @@ class ViaTest < MrubycTestCase
     assert_equal(0x00E4, @via.prk_keycode_into_via_keycode(kc))
   end
 
-  description "via_keycode_into_keysymbol(0x121E) =>:RSFT_1"
-  def translate_to_RSFT_1
-    assert_equal(:RSFT_1, @via.via_keycode_into_keysymbol(0x121E))
+  description "translate to :KC_RPRN"
+  def translate_to_shifted_key
+    assert_equal(:KC_RPRN, @via.via_keycode_into_keysymbol(0x1227))
   end
 
-  description "expand :RSFT_1"
-  def expand_shifted_key
-    assert_equal(%i[KC_RSFT KC_1], @via.expand_composite_key(:RSFT_1) )
+  description "expand :RCTL_1"
+  def expand_key_with_modifier
+    assert_equal(%i[KC_RCTL KC_1], @via.expand_composite_key(:RCTL_1) )
   end
 end


### PR DESCRIPTION
- remove unused VIA.via_keycode_into_prk_keycode()
- remove Keyboard.keycode_into_keysym()