### PR TITLE
Declararive VIA

### DIFF
--- a/src/ruby/sig/keyboard.rbs
+++ b/src/ruby/sig/keyboard.rbs
@@ -58,7 +58,6 @@ class Keyboard
   @anchor: bool
   @anchor_left: bool
   @direct_pins: Array[Integer]
-  @cols_size: Integer
   @matrix: Hash[Integer, Hash[Integer, Array[Integer]]]
   @locked_layer: Symbol | nil
   @keycodes: Array[String]
@@ -80,10 +79,12 @@ class Keyboard
   attr_reader layer: Symbol
   attr_reader split_style: Symbol
   attr_reader sandbox: Sandbox
+  attr_reader cols_size: Integer
+  attr_reader rows_size: Integer
 
   def set_debounce: (Symbol) -> void
   def set_debounce_threshold: (Integer) -> void
-  def append: (RGB | RotaryEncoder | VIA | DebounceNone | DebouncePerRow | DebouncePerKey feature) -> void
+  def append: (RGB | RotaryEncoder | DebounceNone | DebouncePerRow | DebouncePerKey feature) -> void
   def start_features: -> void
   def mutual_uart_at_my_own_risk= : (bool) -> void
   def uart_partner_push8 : (Integer) -> void
@@ -93,6 +94,8 @@ class Keyboard
   def uart_partner_init : (Integer) -> void
 
   def initialize: -> void
+  def via=: (bool) -> void
+  def via_layer_count=: (Integer) -> void
   def bootsel!: -> void
   def set_anchor: (Symbol val) -> void
   def set_scan_mode: (Symbol val) -> void
@@ -106,7 +109,7 @@ class Keyboard
   def add_layer: (Symbol name, Array[ Symbol | Array[Symbol] ] map) -> void
   def find_keycode_index: (Symbol key) -> (Integer | Symbol)
   def define_composite_key: (Symbol key_name, Array[Symbol] keys) -> void
-  def define_mode_key: (Symbol key_name, [Symbol | Array[Symbol] | Proc | nil, Symbol | Proc | nil, Integer?, Integer?] param) -> void
+  def define_mode_key: (Symbol key_name, [Symbol | Array[Symbol] | Proc | nil, Symbol | Proc | nil, Integer?, Integer?] param, ?bool from_via) -> void
   def invert_sft: -> void
   def before_report: () { () -> void } -> void
   def keys_include?: (Symbol) -> bool

--- a/src/ruby/sig/via.rbs
+++ b/src/ruby/sig/via.rbs
@@ -12,10 +12,9 @@ class VIA
 
   attr_accessor kbd: Keyboard
   attr_accessor layer_count: Integer
-  attr_accessor rows_size: Integer
-  attr_accessor cols_size: Integer
-  attr_accessor split_left_cols_size: Integer
 
+  def cols_size: -> Integer
+  def rows_size: -> Integer
   def task: -> void
   def start!: -> void
   def raw_hid_receive : (Array[Integer]) -> Array[Integer]


### PR DESCRIPTION
@yswallow I'd like you to tell me your opinion.

I feel like the VIA feature is fundamental rather than peripheral.
So I want to change APIs like this:

### Before
```ruby
require "via"

kbd = Keyboard.new

kbd.init_pins(
  [ 29, 28, 27, 26, 22, 20, 23 ],
  [ 3, 4, 5, 6, 7, 8, 9]
)

via = VIA.new
via.rows_size = 7
via.cols_size = 7
via.layer_count = 3
via.define_mode_key :VIA_FUNC1, [ :KC_ENTER, :VIA_LAYER1, 150, 150 ]
via.define_mode_key :VIA_FUNC2, [ :KC_SPACE, :VIA_LAYER2, 150, 150 ]
via.define_mode_key :VIA_FUNC3, [ :KC_NO,    :VIA_LAYER3, 150, 150 ]
kbd.append via

kbd.start!
```

### After
```ruby
require "via"

kbd = Keyboard.new

kbd.via = true # This should happen before `kbd.init_pins`
kbd.via_layer_count = 3

kbd.init_pins(
  [ 29, 28, 27, 26, 22, 20, 23 ],
  [ 3, 4, 5, 6, 7, 8, 9]
)

kbd.define_mode_key :VIA_FUNC1, [ :KC_ENTER, :VIA_LAYER1, 150, 150 ]
kbd.define_mode_key :VIA_FUNC2, [ :KC_SPACE, :VIA_LAYER2, 150, 150 ]
kbd.define_mode_key :VIA_FUNC3, [ :KC_NO,    :VIA_LAYER3, 150, 150 ]

kbd.start!
```

This change hides the VIA class from the user.
Users are no longer confused about whether to use `Keyboard#define_mode_key` or `VIA#define_mode_key`.