### PR TITLE
Feature Request: Make the default layer changeable

### DIFF
--- a/src/ruby/app/models/keyboard.rb
+++ b/src/ruby/app/models/keyboard.rb
@@ -459,6 +459,7 @@ class Keyboard
     @mode_keys = Hash.new
     @switches = Array.new
     @layer_names = Array.new
+    @default_layer = :default
     @layer = :default
     @split = false
     @split_style = STANDARD_SPLIT
@@ -479,7 +480,7 @@ class Keyboard
     @sandbox.resume
   end
 
-  attr_accessor :split, :uart_pin
+  attr_accessor :split, :uart_pin, :default_layer
   attr_reader :layer, :split_style, :sandbox, :cols_size, :rows_size
 
   def bootsel!
@@ -984,7 +985,7 @@ class Keyboard
     resume_task("rgb") if $rgb
 
     @keycodes = Array.new
-    prev_layer = :default
+    prev_layer = @default_layer
     modifier_switch_positions = Array.new
     rgb_message = 0
     earlier_report_size = 0
@@ -1085,7 +1086,7 @@ class Keyboard
               end
               mode_key[:released_at] = now
               @layer = prev_layer
-              prev_layer = :default
+              prev_layer = @default_layer
             when :pushed_interrupted, :pushed_then_released_then_pushed
               mode_key[:prev_state] = :released
             when :pushed_then_released
@@ -1097,7 +1098,7 @@ class Keyboard
         end
 
         if @layer != desired_layer
-          prev_layer = @layer if prev_layer != :default
+          prev_layer = @layer if prev_layer != @default_layer
           @layer = desired_layer
         end
 
@@ -1176,7 +1177,7 @@ class Keyboard
           # @type ivar @locked_layer: Symbol
           @layer = @locked_layer
         elsif @switches.empty?
-          @layer = :default
+          @layer = @default_layer
         end
       else
         # Partner


### PR DESCRIPTION
Hello,
I'd like to propose a way to change the default layer.

# Motivation

I use both a Windows PC and a Macbook with a KVM switch, so I would like to change keymaps according to the connected device. 

I wrote using `lock_layer` like the following code, but it is not possible to change a layer with a mode key when the layer is locked.

```ruby
kbd = Keyboard.new

# These are pseudo keymaps, 
kbd.add_layer :default,     %i[ :TO_WIN :RAISE :KC_LGUI :KC_X :KC_C :KC_V ]
kbd.add_layer :default_win, %i[ :UNLOCK :RAISE :KC_LCTL :KC_X :KC_C :KC_V ] # The :RAISE key does not work!
kbd.add_layer :raise,       %i[ :KC_NO  :RAISE :KC_1    :KC_2 :KC_3 :KC_4 ]

kbd.define_mode_key :RAISE, [ :KC_SPACE, :raise, 200, 200 ]

kbd.define_mode_key :TO_WIN, [ Proc.new { kbd.lock_layer(:default_win) } , :KC_NO, 200, nil]
kbd.define_mode_key :UNLOCK, [ Proc.new { kbd.unlock_layer } , :KC_NO, 200, nil]
```

# Proposal

I introduce the accessor to change the default layer.

```ruby
kbd = Keyboard.new

kbd.add_layer :default_mac, %i[ :TO_WIN :RAISE :KC_LGUI :KC_X :KC_C :KC_V ]
kbd.add_layer :default_win, %i[ :TO_MAC :RAISE :KC_LCTL :KC_X :KC_C :KC_V ]
kbd.add_layer :raise,       %i[ :KC_NO  :RAISE :KC_1    :KC_2 :KC_3 :KC_4 ]

kbd.default_layer = :default_mac

kbd.define_mode_key :RAISE, [ :KC_SPACE, :raise, 200, 200 ]

kbd.define_mode_key :TO_WIN, [ Proc.new { kbd.default_layer = :default_win }, :KC_NO, 200, nil]
kbd.define_mode_key :TO_MAC, [ Proc.new { kbd.default_layer = :default_mac  }, :KC_NO, 200, nil]
```

In another use case, it can used to qwerty and dvorak.

```ruby
kbd.default_layer = 'qwerty'

kbd.add_layer :qwerty,  %i[ :SPECIAL :KC_A :KC_S :KC_D  :KC_F  :KC_G ]
kbd.add_layer :dvorak,  %i[ :SPECIAL :KC_A  :KC_O  :KC_E  :KC_U  :KC_I ]
kbd.add_layer :special, %i[ :SPECIAL :TO_QWERTY :TO_DVORAK :KC_NO :KC_NO]

kbd.define_mode_key :SPECIAL, [ :KC_SPACE, :special, 200, 200 ]

kbd.define_mode_key :TO_DVORAK, [ Proc.new { kbd.default_layer = :dvorak }, :KC_NO, 200, nil]
kbd.define_mode_key :TO_QWERTY, [ Proc.new { kbd.default_layer = :qwerty }, :KC_NO, 200, nil]
```

# Other methods

The accessor to `default_layer` is one of simple solutions, I am also thinking of the folloiwing: 

- Make to allow changing layer in `before_report`
- Make to allow changing layer even when the layer is locked