### PR TITLE
RGB Matrix

### DIFF
--- a/src/ruby/app/models/rgb.rb
+++ b/src/ruby/app/models/rgb.rb
@@ -62,7 +62,7 @@ class RGB
       ((rgb[2] + m) * 255).ceil_to_i
   end
 
-  EFFECTS = %i|swirl rainbow_mood breath nokogiri static|
+  EFFECTS = %i|swirl rainbow_mood breath nokogiri static circle|
 
   def effect=(name)
     turn_off
@@ -144,6 +144,8 @@ class RGB
       ws2812_fill(hsv2rgb(@hue, @saturation, @value), @pixel_size)
     when :static
       ws2812_fill(hsv2rgb(@hue, @saturation, @max_value), @pixel_size)
+    when :circle
+      ws2812_circle(@pixel_size, @max_value)
     end
     sleep_ms @delay
   end

--- a/src/ruby/sig/rgb.rbs
+++ b/src/ruby/sig/rgb.rbs
@@ -9,6 +9,7 @@ type effect_type = :swirl
                  | :ruby
                  | :nokogiri
                  | :static
+                 | :circle
 
 # Classes
 class RGB
@@ -25,6 +26,8 @@ class RGB
   def ws2812_set_pixel_at: (Integer, Integer) -> void
   def ws2812_rotate_swirl: (Integer) -> bool
   def ws2812_reset_swirl_index: () -> bool
+  def ws2812_circle: (Integer, Integer) -> void
+  def ws2812_set_pos: (Array[ [Integer, Integer] ]) -> void
 
   @fifo: Array[true]
   @effect: effect_type

--- a/src/ws2812.h
+++ b/src/ws2812.h
@@ -8,7 +8,8 @@ void c_ws2812_rand_show(mrb_vm *vm, mrb_value *v, int argc);
 void c_ws2812_set_pixel_at(mrb_vm *vm, mrb_value *v, int argc);
 void c_ws2812_rotate_swirl(mrb_vm *vm, mrb_value *v, int argc);
 void c_ws2812_reset_swirl_index(mrb_vm *vm, mrb_value *v, int argc);
-
+void c_ws2812_set_pos(mrb_vm *vm, mrb_value *v, int argc);
+void c_ws2812_circle(mrb_vm *vm, mrb_value *v, int argc);
 #define WS2812_INIT() do { \
   mrbc_class *mrbc_class_RGB = mrbc_define_class(0, "RGB", mrbc_class_object);         \
   mrbc_define_method(0, mrbc_class_RGB, "ws2812_init",         c_ws2812_init);         \
@@ -18,5 +19,7 @@ void c_ws2812_reset_swirl_index(mrb_vm *vm, mrb_value *v, int argc);
   mrbc_define_method(0, mrbc_class_RGB, "ws2812_set_pixel_at", c_ws2812_set_pixel_at); \
   mrbc_define_method(0, mrbc_class_RGB, "ws2812_rotate_swirl", c_ws2812_rotate_swirl); \
   mrbc_define_method(0, mrbc_class_RGB, "ws2812_reset_swirl_index", c_ws2812_reset_swirl_index); \
+  mrbc_define_method(0, mrbc_class_RGB, "ws2812_set_pos",      c_ws2812_set_pos); \
+  mrbc_define_method(0, mrbc_class_RGB, "ws2812_circle",       c_ws2812_circle); \
 } while (0)
 


### PR DESCRIPTION
I implemented a pattern `circle`.

Set LED physical position by `rgb.ws2812_set_pos()`.

The range of values is common to QMK. https://docs.qmk.fm/#/feature_rgb_matrix?id=common-configuration
LED flag and LED position in Key Matrix is not implemented.

ex.
```ruby
rgb.ws2812_set_pos( [ [188, 16], [187, 48], [149, 64], [112, 64], [37, 48], [38, 16] ] )
```

And split communication is not implemented yet.

#45