### PR TITLE
Implement PWM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(${PROJECT}
   src/ws2812.c
   src/rotary_encoder.c
   src/joystick.c
+  src/pwm.c
   lib/picoruby/build/repos/host/mruby-bin-picoirb/tools/picoirb/sandbox.c
 )
 
@@ -82,6 +83,7 @@ add_custom_target(models
   COMMAND ${RBC} -Bbuffer         buffer.rb
   COMMAND ${RBC} -Bdebounce       debounce.rb
   COMMAND ${RBC} -Bjoystick       joystick.rb
+  COMMAND ${RBC} -Bpwm            pwm.rb
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ruby/app/models
 )
 

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include "usb_descriptors.h"
 #include "uart.h"
 #include "ws2812.h"
+#include "pwm.h"
 #include "rotary_encoder.h"
 #include "joystick.h"
 #include <sandbox.h>
@@ -28,6 +29,7 @@
 #include "ruby/app/models/rgb.c"
 #include "ruby/app/models/buffer.c"
 #include "ruby/app/models/via.c"
+#include "ruby/app/models/pwm.c"
 #include "ruby/app/models/consumer_key.c"
 #include "ruby/app/models/debounce.c"
 #include "ruby/app/models/joystick.c"
@@ -351,6 +353,12 @@ init_Joystick(void)
   JOYSTICK_INIT();
 }
 
+static void
+init_PWM(void)
+{
+  PWM_INIT();
+}
+
 picogems gems[] = {
   {"keyboard",       NULL,               keyboard,       NULL,     NULL},
   {"debounce",       NULL,               debounce,       NULL,     NULL},
@@ -360,6 +368,7 @@ picogems gems[] = {
   {"via",            NULL,               via,            NULL,     NULL},
   {"consumer_key",   NULL,               consumer_key,   NULL,     NULL},
   {"joystick",       init_Joystick,      joystick,       NULL,     NULL},
+  {"pwm",            init_PWM,           pwm,            NULL,     NULL},
   {NULL,             NULL,               NULL,           NULL,     NULL}
 };
 

--- a/src/pwm.c
+++ b/src/pwm.c
@@ -1,0 +1,59 @@
+#include <mrubyc.h>
+
+#include "pico/stdlib.h"
+#include "hardware/irq.h"
+#include "hardware/pwm.h"
+#include "hardware/clocks.h"
+
+#define PWM_BASE_HZ (1000000UL)
+
+static uint pwm_slice_num;
+static uint32_t pwm_remain_count = 0;
+static uint32_t pwm_wrap_count = 1;
+
+static void
+on_pwm_wrap(void)
+{
+  pwm_clear_irq(pwm_slice_num);
+  if (++pwm_wrap_count>pwm_remain_count)
+  {
+    pwm_set_enabled(pwm_slice_num, false);
+  }
+}
+
+void
+c_pwm_init(mrb_vm *vm, mrb_value *v, int argc)
+{
+  uint8_t pin = GET_INT_ARG(1);
+  uint16_t tone_hz = GET_INT_ARG(2);
+  uint16_t pwm_remain_ms = GET_INT_ARG(3);
+
+  gpio_set_function(pin, GPIO_FUNC_PWM);
+  pwm_slice_num = pwm_gpio_to_slice_num(pin);
+  
+  if (pwm_remain_ms>0) {
+    pwm_remain_count = pwm_remain_ms*tone_hz/1000;
+    pwm_clear_irq(pwm_slice_num);
+    pwm_set_irq_enabled(pwm_slice_num, true);
+    //irq_add_shared_handler(PWM_IRQ_WRAP, on_pwm_wrap, PICO_SHARED_IRQ_HANDLER_DEFAULT_ORDER_PRIORITY);
+    irq_set_exclusive_handler(PWM_IRQ_WRAP, on_pwm_wrap);
+    irq_set_enabled(PWM_IRQ_WRAP, true);
+  } else {
+    pwm_set_irq_enabled(pwm_slice_num, false);
+  }
+  
+  pwm_config config = pwm_get_default_config();
+  pwm_config_set_clkdiv(&config, (float)clock_get_hz(clk_sys)/PWM_BASE_HZ);
+  pwm_config_set_wrap(&config, PWM_BASE_HZ/tone_hz);
+  
+  pwm_init(pwm_slice_num, &config, false);
+
+  pwm_set_gpio_level(pin, (PWM_BASE_HZ/tone_hz)>>1);
+}
+
+void
+c_pwm_enable(mrb_vm *vm, mrb_value *v, int argc)
+{
+  pwm_wrap_count = 1;
+  pwm_set_enabled(pwm_slice_num, true);
+}

--- a/src/pwm.h
+++ b/src/pwm.h
@@ -1,0 +1,10 @@
+#include <mrubyc.h>
+
+void c_pwm_init(mrb_vm *vm, mrb_value *v, int argc);
+void c_pwm_enable(mrb_vm *vm, mrb_value *v, int argc);
+
+#define PWM_INIT() do {\
+  mrbc_class *mrbc_class_PWM = mrbc_define_class(0, "PWM", mrbc_class_object); \
+  mrbc_define_method(0, mrbc_class_PWM, "pwm_init",   c_pwm_init);  \
+  mrbc_define_method(0, mrbc_class_PWM, "pwm_enable", c_pwm_enable);\
+} while (0)

--- a/src/ruby/app/models/keyboard.rb
+++ b/src/ruby/app/models/keyboard.rb
@@ -906,6 +906,10 @@ class Keyboard
     !keycode.nil? && @keycodes.include?(keycode.chr)
   end
 
+  def keys_press?
+    return @keycodes[0].ord != 0
+  end
+
   def action_on_release(mode_key)
     case mode_key.class
     when Integer

--- a/src/ruby/app/models/pwm.rb
+++ b/src/ruby/app/models/pwm.rb
@@ -3,4 +3,8 @@ class PWM
     puts "Init PWM"
     pwm_init(pin, hz, remain_ms)
   end
+
+  def enable
+    pwm_enable
+  end
 end

--- a/src/ruby/app/models/pwm.rb
+++ b/src/ruby/app/models/pwm.rb
@@ -1,0 +1,6 @@
+class PWM
+  def initialize(pin, hz, remain_ms = 100)
+    puts "Init PWM"
+    pwm_init(pin, hz, remain_ms)
+  end
+end

--- a/src/ruby/sig/keyboard.rbs
+++ b/src/ruby/sig/keyboard.rbs
@@ -151,6 +151,7 @@ class Keyboard
   def invert_sft: -> void
   def before_report: () { () -> void } -> void
   def keys_include?: (Symbol) -> bool
+  def keys_press?: () -> bool
   def action_on_release: (Integer | Array[Integer] | Proc | nil) -> void
   def send_key: (*untyped) -> void # 気持ちとしては *(Symbol | Array) だけど書き方わからんかった
   def start!: -> void

--- a/src/ruby/sig/pwm.rbs
+++ b/src/ruby/sig/pwm.rbs
@@ -1,0 +1,6 @@
+class PWM
+  def pwm_init: (Integer, Integer, Integer) -> void
+  def pwm_enable: () -> void
+
+  def initialize: (Integer, Integer, ?Integer) -> void
+end

--- a/src/ruby/sig/pwm.rbs
+++ b/src/ruby/sig/pwm.rbs
@@ -3,4 +3,5 @@ class PWM
   def pwm_enable: () -> void
 
   def initialize: (Integer, Integer, ?Integer) -> void
+  def enable: () -> void
 end


### PR DESCRIPTION
## PWM

### API

#### `pwm.new(pin, tone_hz, millis)`

Set `pin` to use PWM

After `pwm_enable` called, output `tone_hz` wave for `millis` milliseconds.

#### `pwm.pwm_enable()`

Start output.

#### `pwm.enable()`

alias of `pwm_enable()`

#### `kbd.keys_press?`

`true` if any key in keyboard report, else `false`.

### Example

```ruby
require "pwm"

pwm = PWM.new(0, 420, 50)

kbd.before_report do
    if kbd.keys_press?
        # I don't know why, but sleep_ms is needed.
        sleep_ms 1
        pwm.enable
    end
end
```

### UF2

https://github.com/yswallow/prk_firmware/releases/tag/0.9.17-pwm (`pwm.enable` is not implemented)

#32 