### PR TITLE
Wrap `ws2812_set_pos` with `plot_matrix`

### DIFF
--- a/src/ruby/app/models/rgb.rb
+++ b/src/ruby/app/models/rgb.rb
@@ -307,4 +307,8 @@ class RGB
     @fifo.shift
   end
 
+  def plot_matrix(map)
+    ws2812_set_pos(map)
+  end
+
 end

--- a/src/ruby/sig/rgb.rbs
+++ b/src/ruby/sig/rgb.rbs
@@ -67,4 +67,5 @@ class RGB
   def fifo_push: (true data) -> void
   def thunder: -> void
   def ping?: () -> bool
+  def plot_matrix: (Array[ [Integer, Integer] ]) -> void
 end


### PR DESCRIPTION
Reason:

- I don't want methods named `ws2812_xxxx` to expose as an external API that users use in their keymap.rb

@yswallow Is this OK???