### PR TITLE
Implement Tone (formerly called PWM)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,11 +49,13 @@ add_executable(${PROJECT}
   src/ws2812.c
   src/rotary_encoder.c
   src/joystick.c
+  src/tone.c
   lib/picoruby/build/repos/host/mruby-bin-picoirb/tools/picoirb/sandbox.c
 )
 
 pico_generate_pio_header(${PROJECT} ${CMAKE_CURRENT_LIST_DIR}/src/uart_tx.pio)
 pico_generate_pio_header(${PROJECT} ${CMAKE_CURRENT_LIST_DIR}/src/ws2812.pio)
+pico_generate_pio_header(${PROJECT} ${CMAKE_CURRENT_LIST_DIR}/src/tone.pio)
 
 set(RBC ${CMAKE_CURRENT_SOURCE_DIR}/lib/picoruby/bin/picorbc)
 #set(RBC RBENV_VERSION=mruby-3.0.0 mrbc) # In case of PicoRuby compiler enbugged 😵
@@ -82,6 +84,7 @@ add_custom_target(models
   COMMAND ${RBC} -Bbuffer         buffer.rb
   COMMAND ${RBC} -Bdebounce       debounce.rb
   COMMAND ${RBC} -Bjoystick       joystick.rb
+  COMMAND ${RBC} -Btone           tone.rb
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ruby/app/models
 )
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,7 @@
 #include "ws2812.h"
 #include "rotary_encoder.h"
 #include "joystick.h"
+#include "tone.h"
 #include <sandbox.h>
 
 /* ruby */
@@ -31,6 +32,7 @@
 #include "ruby/app/models/consumer_key.c"
 #include "ruby/app/models/debounce.c"
 #include "ruby/app/models/joystick.c"
+#include "ruby/app/models/tone.c"
 /* tasks */
 #include "ruby/app/tasks/usb_task.c"
 #include "ruby/app/tasks/rgb_task.c"
@@ -351,6 +353,12 @@ init_Joystick(void)
   JOYSTICK_INIT();
 }
 
+static void
+init_Tone(void)
+{
+  TONE_INIT();
+}
+
 picogems gems[] = {
   {"keyboard",       NULL,               keyboard,       NULL,     NULL},
   {"debounce",       NULL,               debounce,       NULL,     NULL},
@@ -360,6 +368,7 @@ picogems gems[] = {
   {"via",            NULL,               via,            NULL,     NULL},
   {"consumer_key",   NULL,               consumer_key,   NULL,     NULL},
   {"joystick",       init_Joystick,      joystick,       NULL,     NULL},
+  {"tone",           init_Tone,          tone,           NULL,     NULL},
   {NULL,             NULL,               NULL,           NULL,     NULL}
 };
 

--- a/src/ruby/app/models/keyboard.rb
+++ b/src/ruby/app/models/keyboard.rb
@@ -906,6 +906,10 @@ class Keyboard
     !keycode.nil? && @keycodes.include?(keycode.chr)
   end
 
+  def keys_press?
+    return @keycodes[0].ord != 0
+  end
+
   def action_on_release(mode_key)
     case mode_key.class
     when Integer

--- a/src/ruby/app/models/tone.rb
+++ b/src/ruby/app/models/tone.rb
@@ -1,0 +1,14 @@
+class Tone
+  def initialize(pin)
+    puts "Init Tone"
+    tone_init pin
+  end
+
+  def set_tones(tones)
+    tone_set_tones tones
+  end
+
+  def start
+    tone_start
+  end
+end

--- a/src/ruby/sig/keyboard.rbs
+++ b/src/ruby/sig/keyboard.rbs
@@ -151,6 +151,7 @@ class Keyboard
   def invert_sft: -> void
   def before_report: () { () -> void } -> void
   def keys_include?: (Symbol) -> bool
+  def keys_press?: () -> bool
   def action_on_release: (Integer | Array[Integer] | Proc | nil) -> void
   def send_key: (*untyped) -> void # 気持ちとしては *(Symbol | Array) だけど書き方わからんかった
   def start!: -> void

--- a/src/ruby/sig/tone.rbs
+++ b/src/ruby/sig/tone.rbs
@@ -1,0 +1,9 @@
+class Tone
+  def tone_init: (Integer) -> void
+  def tone_set_tones: (Array[[Integer,Integer]]) -> void
+  def tone_start: () -> void
+
+  def initialize: (Integer) -> void
+  def set_tones: (Array[[Integer,Integer]]) -> void
+  def start: () -> void
+end

--- a/src/tone.c
+++ b/src/tone.c
@@ -1,0 +1,86 @@
+#include <mrubyc.h>
+
+#include "hardware/pio.h"
+#include "hardware/dma.h"
+#include "ws2812.pio.h"
+#include "uart_tx.pio.h"
+#include "tone.pio.h"
+
+#define PIO_TONE_INST_HEAD ( uart_tx_program.length + ws2812_program.length )
+#define TONE_MAX_LEN 64
+#define TONE_BASE_HZ (100000UL)
+
+static PIO pio = pio1;
+static uint sm = 2;
+
+static uint32_t tone_data[TONE_MAX_LEN];
+static int tone_dma_channel = -1;
+
+static void
+init_dma_tone(void)
+{
+  if(tone_dma_channel < 0) {
+    tone_dma_channel = 2; //dma_claim_unused_channel(true);
+  }
+  
+  dma_channel_config c = dma_channel_get_default_config(tone_dma_channel);
+  channel_config_set_transfer_data_size(&c, DMA_SIZE_32);
+  channel_config_set_read_increment(&c, true);
+  channel_config_set_write_increment(&c, false);
+  channel_config_set_dreq(&c, ( pio==pio0 ? DREQ_PIO0_TX0 : DREQ_PIO1_TX0 ) + sm);
+  channel_config_set_irq_quiet(&c, true);
+
+  dma_channel_configure(
+      tone_dma_channel, // Channel to be configured
+      &c,               // The configuration we just created
+      pio->txf+sm,      // The initial write address
+      tone_data,        // The initial read address
+      TONE_MAX_LEN,     // Number of transfers; in this case each is 4 byte.
+      false             // Start immediately.
+  );
+}
+
+void
+c_tone_init(mrb_vm *vm, mrb_value *v, int argc)
+{
+  if(pio_can_add_program_at_offset(pio, &tone_program, PIO_TONE_INST_HEAD)) {
+    pio_add_program_at_offset(pio, &tone_program, PIO_TONE_INST_HEAD);
+  }
+  
+  tone_program_init(pio, sm, PIO_TONE_INST_HEAD, GET_INT_ARG(1));
+  
+  init_dma_tone();
+}
+
+void
+c_tone_set_tones(mrb_vm *vm, mrb_value *v, int argc)
+{
+  mrbc_array *rb_ary = GET_ARY_ARG(1).array;
+  uint8_t tone_count = ( rb_ary->n_stored < TONE_MAX_LEN ) ? (rb_ary->n_stored) : (TONE_MAX_LEN);
+
+  for (uint8_t i=0; i<tone_count; i++)
+  {
+    mrbc_array *item = rb_ary->data[i].array;
+    uint16_t tone = mrbc_integer(item->data[0]);
+    uint16_t tone_ms = mrbc_integer(item->data[1]);
+    
+    if (tone==0)
+    {
+      tone = 1;
+    }
+    tone_data[i] = ( (TONE_BASE_HZ/tone) & 0x0FFF ) | ( (tone_ms*tone<<2) & 0xFFFFF000UL );
+  }
+
+  for (uint8_t i=tone_count; i<TONE_MAX_LEN; i++)
+  {
+    tone_data[i] = 0;
+  }
+}
+
+void
+c_tone_start(mrb_vm *vm, mrb_value *v, int argc)
+{
+  dma_channel_abort(tone_dma_channel);
+  pio_sm_drain_tx_fifo(pio, sm);
+  dma_channel_set_read_addr(tone_dma_channel, tone_data, true);
+}

--- a/src/tone.c
+++ b/src/tone.c
@@ -20,7 +20,7 @@ static void
 init_dma_tone(void)
 {
   if(tone_dma_channel < 0) {
-    tone_dma_channel = 2; //dma_claim_unused_channel(true);
+    tone_dma_channel = dma_claim_unused_channel(true);
   }
   
   dma_channel_config c = dma_channel_get_default_config(tone_dma_channel);
@@ -64,11 +64,12 @@ c_tone_set_tones(mrb_vm *vm, mrb_value *v, int argc)
     uint16_t tone = mrbc_integer(item->data[0]);
     uint16_t tone_ms = mrbc_integer(item->data[1]);
     
-    if (tone==0)
+    if (tone)
     {
-      tone = 1;
+      tone_data[i] = ( (TONE_BASE_HZ/tone) & 0x0FFF ) | ( (tone_ms*tone<<2) & 0xFFFFF000UL );
+    } else {
+      tone_data[i] = (tone_ms<<12);
     }
-    tone_data[i] = ( (TONE_BASE_HZ/tone) & 0x0FFF ) | ( (tone_ms*tone<<2) & 0xFFFFF000UL );
   }
 
   for (uint8_t i=tone_count; i<TONE_MAX_LEN; i++)

--- a/src/tone.h
+++ b/src/tone.h
@@ -1,0 +1,12 @@
+#include <mrubyc.h>
+
+void c_tone_init(mrb_vm *vm, mrb_value *v, int argc);
+void c_tone_set_tones(mrb_vm *vm, mrb_value *v, int argc);
+void c_tone_start(mrb_vm *vm, mrb_value *v, int argc);
+
+#define TONE_INIT() do {\
+  mrbc_class *mrbc_class_Tone = mrbc_define_class(0, "Tone", mrbc_class_object); \
+  mrbc_define_method(0, mrbc_class_Tone, "tone_init",      c_tone_init);  \
+  mrbc_define_method(0, mrbc_class_Tone, "tone_start",     c_tone_start);  \
+  mrbc_define_method(0, mrbc_class_Tone, "tone_set_tones", c_tone_set_tones);\
+} while (0)

--- a/src/tone.pio
+++ b/src/tone.pio
@@ -1,0 +1,45 @@
+.program tone
+
+.wrap_target
+    pull;       blocks
+    out ISR, 12;
+    out Y, 20;
+    mov X, ISR;
+loopOUTER:
+    set pins, 1;
+loopHI:
+    jmp X--, loopHI [5];
+    mov X, ISR;
+    set pins, 0;
+loopLO:
+    jmp X--, loopLO [5];
+    mov X, ISR
+    jmp Y--, loopOUTER;
+.wrap
+
+% c-sdk {
+#include "hardware/clocks.h"
+
+static inline void tone_program_init(PIO pio, uint sm, uint offset, uint pin)
+{
+    pio_gpio_init(pio, pin);
+    pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, true);
+
+    pio_sm_config c = tone_program_get_default_config(offset);
+    
+    // OSR shift_right, auto_pull, threshould
+    sm_config_set_out_shift(&c, true, false, 32);
+    
+    sm_config_set_out_pins(&c, pin, 1);
+    sm_config_set_set_pins(&c, pin, 1);
+    
+    // all the FIFOs is TX
+    //sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
+    sm_config_set_clkdiv(&c, (float)clock_get_hz(clk_sys) / (1000000UL));
+
+    // start state machine
+    pio_sm_init(pio, sm, offset, &c);
+    pio_sm_set_enabled(pio, sm, true);
+}
+
+%}

--- a/src/tone.pio
+++ b/src/tone.pio
@@ -4,8 +4,9 @@
     pull;       blocks
     out ISR, 12;
     out Y, 20;
-    mov X, ISR;
 loopOUTER:
+    mov X, ISR;
+    jmp !X, noTone;
     set pins, 1;
 loopHI:
     jmp X--, loopHI [5];
@@ -13,7 +14,12 @@ loopHI:
     set pins, 0;
 loopLO:
     jmp X--, loopLO [5];
-    mov X, ISR
+    jmp loopOuterEND;
+noTone:
+    set X, 0x1F; set 0b00011111
+loopZERO:
+    jmp X--, loopZERO [31]; wait for 900 clocks
+loopOuterEND:
     jmp Y--, loopOUTER;
 .wrap
 
@@ -30,7 +36,7 @@ static inline void tone_program_init(PIO pio, uint sm, uint offset, uint pin)
     // OSR shift_right, auto_pull, threshould
     sm_config_set_out_shift(&c, true, false, 32);
     
-    sm_config_set_out_pins(&c, pin, 1);
+    //sm_config_set_out_pins(&c, pin, 1);
     sm_config_set_set_pins(&c, pin, 1);
     
     // all the FIFOs is TX


### PR DESCRIPTION
## Tone

### API

#### `tone.new(pin)`

Set `pin` to use Tone.

#### `tone.set_tones( [ [tone1,tone_ms1], [tone2, tone_ms2], ... ] )`

Set tone sequence. (overwrites current sequence)

#### `tone.start()`

Start sequence.

#### `kbd.keys_press?`

`true` if any key in keyboard report, else `false`.

### Limitation

tone_ms*tone < 1,000,000

tone: 0 or >25

### Example

```ruby
require "tone"

tone = Tone.new(14)

tone.set_tones( [[349,250],[466,375],[440,375],[349,250],[0,125],[349,375],[392,1000], [0,125],[392,250],[523,375],[440,375],[392,250],[0,125],[392,375],[349,1000] ] )
tone.start

press = false

kbd.before_report do
    if kbd.keys_press? 
        unless press
            press = true
            tone.set_tones( [ [440,50],[880,50] ] )
            tone.start
        end
    elsif press
        press = false
    end
end

kbd.start!
```

### UF2

https://github.com/yswallow/prk_firmware/releases/tag/0.9.17-pio-tone

#32 
#138 