### PR TITLE
RGB Matrix on Split Keyboard

### DIFF
--- a/src/ruby/app/models/keyboard.rb
+++ b/src/ruby/app/models/keyboard.rb
@@ -511,6 +511,21 @@ class Keyboard
       # @type var feature: RGB
       $rgb = feature
       $rgb.anchor = @anchor
+      if @split
+        if @anchor==@anchor_left
+          # left
+          $rgb.ws2812_circle_set_center(224,32)
+        else
+          # right
+          if @split_style == :right_side_flipped_split
+            $rgb.ws2812_circle_set_center(0,32)
+          else
+            $rgb.ws2812_circle_set_center(224,32)
+          end
+        end
+      else
+        $rgb.ws2812_circle_set_center(112,32)
+      end
     when "RotaryEncoder"
       # @type var feature: RotaryEncoder
       if @split

--- a/src/ruby/app/models/rgb.rb
+++ b/src/ruby/app/models/rgb.rb
@@ -213,7 +213,7 @@ class RGB
     @delay = (33 - @speed) * 10
     unless @anchor
       # speed tuning (partner is slower due to blocking UART)
-      @delay = (@delay * 0.9).ceil_to_i
+      @delay = (@delay * 0.97).ceil_to_i
     end
   end
 
@@ -299,7 +299,7 @@ class RGB
         @ascent = true
         @value = 0.0
       when :circle
-        @circle_diameter = 10
+        @circle_diameter = 11
       end
     when 0
       puts "ERROR: This should not happen"

--- a/src/ruby/app/models/rgb.rb
+++ b/src/ruby/app/models/rgb.rb
@@ -152,9 +152,15 @@ class RGB
     when :circle
       unless @effect_init
         ws2812_init_pixel_distance(@pixel_size)
+        @circle_diameter = 0
         @effect_init = true
       end
-      ws2812_circle(@pixel_size, @max_value)
+      @circle_diameter -= 1
+      if @circle_diameter < 0
+        @ping = true
+        @circle_diameter = 11
+      end
+      ws2812_circle(@pixel_size, @max_value, @circle_diameter)
     end
     sleep_ms @delay
   end
@@ -292,6 +298,8 @@ class RGB
       when :breath, :nokogiri
         @ascent = true
         @value = 0.0
+      when :circle
+        @circle_diameter = 10
       end
     when 0
       puts "ERROR: This should not happen"

--- a/src/ruby/sig/rgb.rbs
+++ b/src/ruby/sig/rgb.rbs
@@ -26,7 +26,7 @@ class RGB
   def ws2812_set_pixel_at: (Integer, Integer) -> void
   def ws2812_rotate_swirl: (Integer) -> bool
   def ws2812_reset_swirl_index: () -> bool
-  def ws2812_circle: (Integer, Integer) -> void
+  def ws2812_circle: (Integer, Integer, Integer) -> void
   def ws2812_add_matrix_pixel_at: (Integer, Integer, Integer) -> void
   def ws2812_init_pixel_distance: (Integer) -> void
 
@@ -38,6 +38,7 @@ class RGB
   @max_value: Integer
   @value: Float
   @hue: Integer
+  @circle_diameter: Integer
   @srand: bool
   @ascent: bool
   @offed: bool

--- a/src/ruby/sig/rgb.rbs
+++ b/src/ruby/sig/rgb.rbs
@@ -29,6 +29,7 @@ class RGB
   def ws2812_circle: (Integer, Integer, Integer) -> void
   def ws2812_add_matrix_pixel_at: (Integer, Integer, Integer) -> void
   def ws2812_init_pixel_distance: (Integer) -> void
+  def ws2812_circle_set_center: (Integer, Integer) -> void
 
   @fifo: Array[true]
   @effect: effect_type

--- a/src/ws2812.c
+++ b/src/ws2812.c
@@ -158,6 +158,7 @@ c_ws2812_rand_show(mrb_vm *vm, mrb_value *v, int argc)
 
 static uint8_t matrix_coordinate[MAX_PIXEL_SIZE][2];
 static uint32_t pixel_distance[MAX_PIXEL_SIZE];
+static uint8_t circle_center[2] = { 112, 32 };
 
 void
 c_ws2812_add_matrix_pixel_at(mrb_vm *vm, mrb_value *v, int argc)
@@ -168,13 +169,20 @@ c_ws2812_add_matrix_pixel_at(mrb_vm *vm, mrb_value *v, int argc)
 }
 
 void
+c_ws2812_circle_set_center(mrb_vm *vm, mrb_value *v, int argc)
+{
+  circle_center[0] = GET_INT_ARG(1);
+  circle_center[1] = GET_INT_ARG(2);
+}
+
+void
 c_ws2812_init_pixel_distance(mrb_vm *vm, mrb_value *v, int argc)
 {
   int32_t x;
   int32_t y;
   for (int i=0; i < GET_INT_ARG(1); i++) {
-    x = matrix_coordinate[i][0] - 112;
-    y = (matrix_coordinate[i][1] - 32) * 3;
+    x = matrix_coordinate[i][0] - circle_center[0];
+    y = (matrix_coordinate[i][1] - circle_center[1]) * 3;
     pixel_distance[i] = x * x + y * y;
   }
 }
@@ -201,8 +209,23 @@ static inline uint8_t get_distance_group(uint32_t d) {
   } else if(d<19600) {
     // 140
     return 6;
-  } else {
+  } else if(d<25600) {
+    // 160
     return 7;
+  } else if(d<32800) {
+    // 180
+    return 8;
+  } else if(d<40000) {
+    // 200
+    return 9;
+  } else if(d<48400) {
+    // 220
+    return 10;
+  } else if(d<57600) {
+    // 240
+    return 11;
+  } else {
+    return 12;
   }
 }
 

--- a/src/ws2812.c
+++ b/src/ws2812.c
@@ -158,7 +158,6 @@ c_ws2812_rand_show(mrb_vm *vm, mrb_value *v, int argc)
 
 static uint8_t matrix_coordinate[MAX_PIXEL_SIZE][2];
 static uint32_t pixel_distance[MAX_PIXEL_SIZE];
-static uint8_t circle_diameter = 0;
 
 void
 c_ws2812_add_matrix_pixel_at(mrb_vm *vm, mrb_value *v, int argc)
@@ -214,14 +213,10 @@ c_ws2812_circle(mrb_vm *vm, mrb_value *v, int argc)
 {
   int count = GET_INT_ARG(1);
   int value = GET_INT_ARG(2);
+  int circle_diameter = GET_INT_ARG(3);
 
-  uint8_t lv = value;
+  uint8_t lv = value*2;
 
-  if(circle_diameter==0) {
-    circle_diameter = 11;
-  } else {
-    --circle_diameter;
-  }
   for(uint16_t i=0; i<count; i++) {
     uint8_t b = get_distance_group(pixel_distance[i]);
     

--- a/src/ws2812.h
+++ b/src/ws2812.h
@@ -11,6 +11,7 @@ void c_ws2812_reset_swirl_index(mrb_vm *vm, mrb_value *v, int argc);
 void c_ws2812_circle(mrb_vm *vm, mrb_value *v, int argc);
 void c_ws2812_add_matrix_pixel_at(mrb_vm *vm, mrb_value *v, int argc);
 void c_ws2812_init_pixel_distance(mrb_vm *vm, mrb_value *v, int argc);
+void c_ws2812_circle_set_center(mrb_vm *vm, mrb_value *v, int argc);
 
 #define WS2812_INIT() do { \
   mrbc_class *mrbc_class_RGB = mrbc_define_class(0, "RGB", mrbc_class_object);         \
@@ -24,5 +25,6 @@ void c_ws2812_init_pixel_distance(mrb_vm *vm, mrb_value *v, int argc);
   mrbc_define_method(0, mrbc_class_RGB, "ws2812_add_matrix_pixel_at", c_ws2812_add_matrix_pixel_at); \
   mrbc_define_method(0, mrbc_class_RGB, "ws2812_init_pixel_distance", c_ws2812_init_pixel_distance); \
   mrbc_define_method(0, mrbc_class_RGB, "ws2812_circle",       c_ws2812_circle); \
+  mrbc_define_method(0, mrbc_class_RGB, "ws2812_circle_set_center", c_ws2812_circle_set_center); \
 } while (0)
 


### PR DESCRIPTION
## todo

- [x] integrated pattern (place circle center on keyboard center) on split keyboard

## UF2

https://github.com/yswallow/prk_firmware/releases/tag/0.9.18-rgb-split
