### PR TITLE
Update package database on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM --platform=amd64 manjarolinux/base AS build
 
-RUN pacman -S --noconfirm \
+RUN pacman -Sy --noconfirm \
   cmake \
   arm-none-eabi-gcc \
   arm-none-eabi-newlib \


### PR DESCRIPTION
The package database included in the docker image is out of date.
This causes a 404 error when retrieving packages.