### PR TITLE
Update Dockerfile and Rakefile for pico sdk 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pacman -Sy --noconfirm \
   ruby-rake \
   ruby-bundler
 
-RUN git clone https://github.com/raspberrypi/pico-sdk.git -b 1.4.0
+RUN git clone https://github.com/raspberrypi/pico-sdk.git -b 1.5.0
 RUN cd /pico-sdk/lib && git submodule update --init ./
 ENV PICO_SDK_PATH "/pico-sdk"
 

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ end
 
 task :check_pico_sdk => :check_pico_sdk_path do
   FileUtils.cd ENV["PICO_SDK_PATH"] do
-    unless `git status --branch`.split("\n")[0].end_with?(PICO_SDK_TAG)
+    unless `git describe --tags`.strip.end_with?(PICO_SDK_TAG)
       raise <<~MSG
         pico-sdk #{PICO_SDK_TAG} is not checked out!\n
         Tips for dealing with:\n


### PR DESCRIPTION
This fixes the Docker-based build (`docker compose run --rm prk rake`) issues I encountered in my environment. I use Docker Desktop 4.11.1 on macOS 12.6.3 M1 Pro. I have not tested it in other environments.

* `PICO_SDK_TAG` is set to `1.5.0` in Rakefile. Updated in Dockerfile.
* In my environment, pico-sdk version check fails because `git status --branch` does not seem to return the tag:
```
# git status --branch
Not currently on any branch.
nothing to commit, working tree clean
```
but `git describe --tags` works:
```
# git describe --tags
1.5.0
```